### PR TITLE
Add bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**System information (please complete the following information):**
+ - OS: [e.g. alpine linux]
+ - Sub-program: [e.g. message verifier, xcall, goloop]
+ - Version (if applicable): [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/issue-report.md
+++ b/.github/ISSUE_TEMPLATE/issue-report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug report
+name: Issue report
 about: Create a report to help us improve
 title: ''
 labels: ''
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Describe the issue**
+A clear and concise description of what the issue is.
 
 **To reproduce**
 Steps to reproduce the behavior:


### PR DESCRIPTION
Add bug report issue template based on template used in other ICON ecosystem projects (https://github.com/icon-community/template-repository/blob/master/.github/ISSUE_TEMPLATE/bug-report.md)

This is to be used for the focus testing program, the incentivized xcall testnet program, and for general bug reports about btp by the public technical community